### PR TITLE
When sorting by Time, do not consider PAX multiplier

### DIFF
--- a/site/src/scenes/results/Results.tsx
+++ b/site/src/scenes/results/Results.tsx
@@ -28,6 +28,14 @@ function Results() {
   const [selectedSortBy, setSelectedSortBy] = useState(
     sessionStorage.getItem("sortBy") || "class"
   );
+
+  // refresh results when sort by changes so that times are parsed correctly
+  useEffect(() => {
+    fetch("live/data.html")
+      .then((response) => response.text())
+      .then((data) => setResults(parseResultsFromHtml(data)));
+  }, [selectedSortBy]);
+
   const [currentDriverClass, setCurrentDriverClass] = useState(
     sessionStorage.getItem("class") || "all"
   );

--- a/site/src/scenes/results/util.tsx
+++ b/site/src/scenes/results/util.tsx
@@ -201,7 +201,11 @@ export const parseResults = (data: any) => {
     let runDisplay = "";
 
     if (indexedClass !== undefined) {
-      fastest = row.Total.split("/")[0].trim();
+      // if we are viewing all results sorted by time, we should pax these results so we can compare across classes
+      const isTimeSort = sessionStorage.getItem("sortBy") === "time";
+      fastest = isTimeSort
+        ? row.Total.split("/")[1].trim()
+        : row.Total.split("/")[0].trim();
       fastestRunInfo.time = fastest;
     } else {
       fastest = actualTime(fastestRunInfo);


### PR DESCRIPTION
Removing the PAX calc from the Sort By Time view. This allows us to better compare across classes. It was a pretty common complaint on Saturday

Sort By Class
![image](https://github.com/user-attachments/assets/c181d2aa-a816-45e6-97a9-9458dd2df80c)

Sort By Time
![image](https://github.com/user-attachments/assets/3226397c-f982-44ca-b815-ae7b632d7eb7)
