### PR TITLE
Updating some styling

### DIFF
--- a/site/src/scenes/results/components/Driver.tsx
+++ b/site/src/scenes/results/components/Driver.tsx
@@ -7,18 +7,21 @@ import Runs from "./Runs";
 const Driver = (props: any) => {
   const [open, setOpen] = useState(false);
 
-  const isHardo = props.driver.class === "hardo";
+  const isHardo = props.driver.class === "hardo" && !props.sortedByTime;
 
   return (
     <div key={props.position + 1} className="container-fluid">
       <div className="card w-100 border-darkmode mt-2">
         <div className="row g-3 align-items-center">
-          <div className="col-1 d-flex justify-content-center">
+          <div className="col-1 d-flex flex-column justify-content-center align-items-center">
             <h4 className="driverPosition">
               {props.position !== null && props.position
                 ? props.position
                 : props.driver.position}
             </h4>
+            {props.sortedByTime && (
+              <div className="card-text">{props.driver.class}</div>
+            )}
           </div>
           <div className="col-4">
             <div key={props.position + 1} className="row">

--- a/site/src/scenes/results/components/ResultsSorter.jsx
+++ b/site/src/scenes/results/components/ResultsSorter.jsx
@@ -26,7 +26,7 @@ const ResultsSorter = (props) => {
   }
 
   return (
-    <>
+    <div style={{ paddingBottom: "200px" }}>
       {/* {console.log(props.results)} */}
       {props.selectedSortBy === "class" && (
         <DriverClasses
@@ -45,6 +45,7 @@ const ResultsSorter = (props) => {
               key={position + 1}
               driver={driver}
               position={position + 1}
+              sortedByTime
             />
           ))}
         </div>
@@ -63,7 +64,7 @@ const ResultsSorter = (props) => {
             ))}
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/site/src/scenes/results/components/Runs.jsx
+++ b/site/src/scenes/results/components/Runs.jsx
@@ -7,13 +7,13 @@ const Runs = ({ runs, fastestRunInfo }) => {
           <div key={key + 1} className="col">
             <p className="card-text">
               <b>{key + 1}</b>:{" "}
-              <span
-                className={
-                  key + 1 === fastestRunInfo.number ? "text-success" : ""
-                }
-              >
-                {run.display}
-              </span>
+              {key + 1 === fastestRunInfo.number ? (
+                <span className={"text-success"}>
+                  <b>{run.display}</b>
+                </span>
+              ) : (
+                <span>{run.display}</span>
+              )}
             </p>
           </div>
         ))}


### PR DESCRIPTION
Removed the Pax times from the "Sort by time" page

Added the class name when viewing "Sort by time" so it's easier to see overall where you placed

<img width="1112" height="536" alt="image" src="https://github.com/user-attachments/assets/55c117b4-2f60-4eae-a265-f01cb1898eef" />

added some padding to the bottom of the results so its easier to tell when you are at the bottom.